### PR TITLE
turn on quickSuggestions for tailwind classes

### DIFF
--- a/app/.vscode/settings.json
+++ b/app/.vscode/settings.json
@@ -5,5 +5,8 @@
     "kysely",
     "preact",
     "twind"
-  ]
+  ],
+  "editor.quickSuggestions": {
+    "strings": "on"
+  }
 }


### PR DESCRIPTION
Turn on `quickSuggestions` for strings to trigger completions when editing "string" content.