### PR TITLE
Readme

### DIFF
--- a/app/README.md
+++ b/app/README.md
@@ -18,6 +18,12 @@ Update the values accordingly (if using Docker, the values can stay as is).
 Discord client id and secret can be acquired
 [here](https://discord.com/developers/applications).
 
+Under OAuth2 a new redirect should be added pointing to:
+
+```
+http://localhost:8000/auth/discord/callback
+```
+
 ### Database
 
 If using Docker, you can run from this directory to spin up a postgres database:

--- a/app/README.md
+++ b/app/README.md
@@ -32,6 +32,12 @@ If using Docker, you can run from this directory to spin up a postgres database:
 docker-compose start
 ```
 
+After this it's important to run:
+
+```sh
+deno task migrate:up
+```
+
 ### Usage
 
 Start the project (this will install dependencies on first run):


### PR DESCRIPTION
Updated the README.md to include 2 missing steps.

Adding the OAuth2 redirect on Discord.

Run `deno task migrate:up` Please confirm this, but until I run this, I got errors after login that looked like this:

```
An error occured during route handling or page rendering.

PostgresError: relation "social_profile" does not exist
    at Connection.#preparedQuery (https://deno.land/x/postgres@v0.16.1/connection/connection.ts:879:19)
    at async Connection.query (https://deno.land/x/postgres@v0.16.1/connection/connection.ts:951:16)
    at async Client.#executeQuery (https://deno.land/x/postgres@v0.16.1/client.ts:245:12)
    at async Client.queryObject (https://deno.land/x/postgres@v0.16.1/client.ts:433:12)
    at async PgConnection.executeQuery (file:///home/cherry/GithubMAM/fresh-spots/app/db/PostgresDriver.ts:77:22)
    at async PgConnection.connection.executeQuery (https://cdn.jsdelivr.net/npm/kysely@0.21.4/dist/esm/driver/runtime-driver.js:74:24)
    at async https://cdn.jsdelivr.net/npm/kysely@0.21.4/dist/esm/query-executor/query-executor-base.js:34:28
    at async DefaultConnectionProvider.provideConnection (https://cdn.jsdelivr.net/npm/kysely@0.21.4/dist/esm/driver/default-connection-provider.js:10:20)
    at async DefaultQueryExecutor.executeQuery (https://cdn.jsdelivr.net/npm/kysely@0.21.4/dist/esm/query-executor/query-executor-base.js:33:16)
    at async SelectQueryBuilder.execute (https://cdn.jsdelivr.net/npm/kysely@0.21.4/dist/esm/query-builder/select-query-builder.js:632:24)
    ```