### PR TITLE
updated postgres to 0.17.0

### DIFF
--- a/app/deps.ts
+++ b/app/deps.ts
@@ -1,7 +1,7 @@
 export * as z from "https://deno.land/x/zod@v3.18.0/mod.ts";
 export * as flags from "https://deno.land/std@0.153.0/flags/mod.ts";
 export * as kysely from "https://cdn.jsdelivr.net/npm/kysely@0.21.4/dist/esm/index.js";
-export * as postgres from "https://deno.land/x/postgres@v0.16.1/mod.ts";
+export * as postgres from "https://deno.land/x/postgres@v0.17.0/mod.ts";
 export * as squishyCookies from "https://deno.land/x/squishy_cookies@v0.2.4/mod.ts";
 export * as cookie from "https://deno.land/std@0.153.0/http/cookie.ts";
 export { default as slugify } from "https://esm.sh/slugify@1.6.5";


### PR DESCRIPTION
updating postgres to 0.17.0 to support `password_encryption = 'scram-sha-256'` in latest postgres v15 

see https://github.com/CodingGarden/fresh-spots/issues/67